### PR TITLE
Support for now.json build.env fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 dist
-
+package-lock.json
 # Logs
 logs
 *.log
@@ -22,6 +22,9 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# IDE - JetBrains
+.idea
 
 # envs
 .env

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,13 @@ cli.options({
     description: `Overwrite whole now.stage.json (@default: false)`,
   },
 
+  build: {
+    alias: 'b',
+    required: false,
+    type: 'boolean',
+    description: `Overwrite build.env section of now.stage.json (@default: false)`,
+  },
+
   codegen: {
     alias: 'c',
     required: false,

--- a/src/now-dotenv.ts
+++ b/src/now-dotenv.ts
@@ -25,6 +25,7 @@ export class NowDotenv {
       syncApi: true,
       syncJson: true,
       overwrite: false,
+      build: false,
       ...options,
     }
 
@@ -161,10 +162,19 @@ export class NowDotenv {
     if (!json.env) {
       json = { ...json, env: {} }
     }
+    if (this.options.build && (!json.build || !json.build.env)) {
+      if (!json.build) {
+        json = { ...json, build: {} }
+      }
+      json = { ...json, build: { ...json.build, env: {} } }
+    }
 
     Object.keys(this.envs).forEach(name => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       json!.env![name] = '@' + this.formatName(name)
+      if (this.options.build) {
+        json!.build!.env![name] = '@' + this.formatName(name)
+      }
     })
 
     this.writeNowJson(json)
@@ -187,10 +197,19 @@ export class NowDotenv {
     if (!json.env) {
       json = { ...json, env: {} }
     }
+    if (this.options.build && (!json.build || !json.build.env)) {
+      if (!json.build) {
+        json = { ...json, build: {} }
+      }
+      json = { ...json, build: { ...json.build, env: {} } }
+    }
 
     Object.keys(this.envs).forEach(name => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       json!.env![name] = '@' + this.formatName(name)
+      if (this.options.build) {
+        json!.build!.env![name] = '@' + this.formatName(name)
+      }
     })
 
     this.writeNowJson(json)

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,12 @@ export interface NowDotenvOptions {
    */
   overwrite?: boolean
   /**
+   * should overwrite build.env of now.stage.json with now.json
+   *
+   * @default false
+   */
+  build?: boolean
+  /**
    * generate global typescript typings for process.env at provided path
    */
   codegen?: string
@@ -73,6 +79,11 @@ export interface NowJson {
   name?: string
   env?: {
     [name: string]: string
+  }
+  build?: {
+    env?: {
+      [name: string]: string
+    }
   }
 }
 


### PR DESCRIPTION
added support for generating now.json build.env vars
added JetBrains folders and package-lock.json to .gitignore